### PR TITLE
fix: add io.elhan.play-services-resolver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "name": "Alperen Elhan",
     "email": "alperen@elhan.io",
     "url": "https://elhan.io"
+  },
+  "dependencies": {
+    "io.elhan.play-services-resolver": "0.1.0"
   }
 }


### PR DESCRIPTION
Based on https://github.com/oae/unity-package-facebook-sdk/pull/1#issuecomment-586686263, the `io.elhan.play-services-resolver` dependency should be added to the `package.json`.